### PR TITLE
Add scale units and error to Astrometry.net call

### DIFF
--- a/Scripts/astrometry.py
+++ b/Scripts/astrometry.py
@@ -88,7 +88,9 @@ def main():
 			cmd = f'python client.py -k {p.apikey} \
 									--upload "{fn}" \
 									--parity 1 \
+									--scale-units arcsecperpix \
 									--scale-est {scale} \
+									--scale-err 10.0 \
 									--corr "{fn[:-4]}_corr.fit" \
 									--calibrate "{fn[:-4]}_calib.txt"'
 


### PR DESCRIPTION
Just learned this from working on the CCD pipeline, but when calling the `client.py` script for Astrometry.net, both the `--scale-est` and `--scale-err` parameters have to be used, otherwise `--scale-est` will be ignored (see lines 332 - 339 in `client.py`) and Astrometry.net will fall back to the default of just using 0.1 and 180 degrees as the lower and upper limits on the total image width. Additionally, the `--scale-units` parameter must be specified as `arcsecperpix` since the default is `degwidth`.  The `--scale-err` parameter is just in percentage units.

I imagine this change won't have much impact on the accuracy of the image solving, though the solving may go a little faster since it will narrow the range of image scales that Astrometry.net has to search through.